### PR TITLE
Fix variables type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -186,7 +186,7 @@ variable "affinity" {
 
 variable "security_context" {
   description = "Security context for pods defined as a map which will be serialized to JSON."
-  type        = map(any)
+  type        = any
   default = {
     runAsGroup = 472
     runAsUser  = 472
@@ -435,7 +435,7 @@ variable "image_renderer_priority_class_name" {
 
 variable "image_renderer_security_context" {
   description = "image-renderer deployment securityContext"
-  type        = map(any)
+  type        = any
   default     = {}
 }
 


### PR DESCRIPTION
Faced this error with securityContext:

```
│ Error: Invalid value for module argument
│
│   on main.tf line 248, in module "grafana":
│  248:   security_context = {
│  249:     runAsGroup = 472
│  250:     runAsUser  = 0
│  251:     fsGroup    = 0
│  252:     seccompProfile = {
│  253:       type = "RuntimeDefault"
│  254:     }
│  255:   }
│
│ The given value is not suitable for child module variable
│ "security_context" defined at
│ .terraform/modules/grafana/variables.tf:187,1-28: all map elements must
│ have the same type.
╵
ERRO[0019] 1 error occurred:
        * exit status 1
```